### PR TITLE
fix: bind variable used in defer

### DIFF
--- a/passkb_darwin.go
+++ b/passkb_darwin.go
@@ -41,6 +41,7 @@ func (kb macKeyboard) Type(str string, delay time.Duration) error {
 	events := make([]C.CGEventRef, 2*len(str))
 
 	for i, r := range str {
+		i := i
 		events[2*i] = C.cgeventcreatekeyboardevent(C.ushort(r), true)
 		if events[2*i] == 0 {
 			return fmt.Errorf("Cannot create a key down event for %v", r)


### PR DESCRIPTION
the loop index variable `i` is used in a deferred statement. Without a local copy, the 
variable's value when invoked will be its value on the final iteration for all deferred 
statements.