### PR TITLE
Include ApplicationServices.h to avoid unknown type name errors

### DIFF
--- a/passkb_darwin.go
+++ b/passkb_darwin.go
@@ -5,6 +5,8 @@ package passkb
 #cgo LDFLAGS: -framework Cocoa
 #import <Foundation/Foundation.h>
 
+#include <ApplicationServices/ApplicationServices.h>
+
 CGEventRef cgeventcreatekeyboardevent(unsigned short c, bool down) {
 	// real key code does not matter as we are overriding with CGEventKeyboardSetUnicodeString
 	CGEventRef cf = CGEventCreateKeyboardEvent(NULL, 0, down);


### PR DESCRIPTION
ApplicationServices.h must be included on modern Darwin systems to avoid unknown type name 'CGEventRef' errors.

Signed-off-by: Renat Nurgaliyev <renat@rnu.one>